### PR TITLE
UX: Make post's title clickable

### DIFF
--- a/components/common/post.tsx
+++ b/components/common/post.tsx
@@ -21,7 +21,9 @@ const Post = ({ post }: Props) => {
         <div className="relative bg-white">
           <div className="py-10 px-8">
             <h3 className="text-2xl font-bold" style={{ height: 100, overflow: 'hidden' }}>
+              <a href={post.url} target="_blank" rel="noopener noreferrer">
               {post.title}
+              </a>
             </h3>
             <div className="text-gray-600 text-sm font-medium flex mb-4 mt-2">
               <p>Publish date: {formatDate(post.published_at)}</p>


### PR DESCRIPTION
Add a link tag to the post title, so the user can directly click on it to open the article.

Motivation:
I made it because it was the natural way i tried to use to open the link, and it didn't work, and i think a lot of visitor will try the same.